### PR TITLE
Changed resistor value

### DIFF
--- a/Lesson-2/teacher-instructions.md
+++ b/Lesson-2/teacher-instructions.md
@@ -9,7 +9,7 @@ For this scheme of work students will need access to:
 - An Ethernet cable for each pair of Raspberry Pis
 - The `network.py` file
 - Four female-to-female header leads
-- A 270k resistor
+- A 270 ohm resistor
 - An LED
 - A button (or paperclip or similar)
 


### PR DESCRIPTION
After trying out this exercise I found out the LED was not lighting because the value of the resistor was too high (originally written as 270k ohm). My scrappy electronics knowledge suggests that 270 ought to work instead, but I'll check this when I get some lower value resistors...
