### PR TITLE
Remove format step from instructions

### DIFF
--- a/lesson-1/teacher-instructions.md
+++ b/lesson-1/teacher-instructions.md
@@ -27,5 +27,5 @@ Once you have completed the steps above, you are able to make a copy of your mas
 1. On Windows use [Win disk 32 imager](http://sourceforge.net/projects/win32diskimager/) to make a copy of an SD card. On Mac OS X you can use the `dd` command or a [dd-gui](http://www.gingerbeardman.com/dd-gui/).
 1. Remove the master SD card and keep it safe.
 1. Take a fresh SD card and insert it into your computer or laptop.
-1. Format the SD card then, using your imaging software, select the image and write it to the card.
+1. Using your imaging software, select the image and write it to the card.
 1. Repeat the last step for the rest of your cards.

--- a/lesson-2/teacher-instructions.md
+++ b/lesson-2/teacher-instructions.md
@@ -31,7 +31,7 @@ Once you have completed the steps above, you are able to make a copy of your mas
 1. On windows use [Win disk 32 imager](http://sourceforge.net/projects/win32diskimager/) to make a copy of an SD card. On MAC OSX you can use the `dd` command or a [dd-gui](http://www.gingerbeardman.com/dd-gui/).
 1. Remove the master SD card and keep it safe.
 1. Take a fresh SD card and insert it into your computer or laptop.
-1. Format the SD card then, using your imaging software, select the image and write it to the card.
+1. Using your imaging software, select the image and write it to the card.
 1. Repeat the last step for the rest of your cards.
 
 ## Introduction to GPIO


### PR DESCRIPTION
Because when using 'dd' or Win32DiskImager there's no need to format the SD card first, since the whole thing gets overwritten anyway.