### PR TITLE
Add pip3 install

### DIFF
--- a/software.md
+++ b/software.md
@@ -8,15 +8,8 @@ First update and upgrade your system. Enter the following commands into the term
 sudo apt-get update
 sudo apt-get upgrade
 ```
+Now you need to install the network package for Python3 using pip3:
 
-## Downloading network.py
-
-1. After booting, log in using the default login `pi` and password `raspberry`.
-
-1. On the command line type:
-    
-    ```bash
-    wget https://goo.gl/UJMdZh -O network.py --no-check-certificate
-    ```
-    
-1. Type `ls` to check that the file has downloaded.
+```bash
+sudo pip3 install network
+```

--- a/software.md
+++ b/software.md
@@ -1,6 +1,6 @@
 # Software installation
 
-You'll need to be online to install packages.
+You will need to be online to install packages.
 
 First update and upgrade your system. Enter the following commands into the terminal:
 


### PR DESCRIPTION
We can use pip3 to install network and remove the need for downloading via the Google URL thanks to David and Andrew getting the network package into PyPi here: https://pypi.python.org/pypi/network